### PR TITLE
SNS Topic from Fn:ImportValue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ class ServerlessSnsToSqsEvents {
 	}
 
 	isArn(input) {
-		return _.isString(input) || input.Ref || input["Fn::GetAtt"] || input["Fn::Import"] || input["Fn::Sub"];
+		return _.isString(input) || input.Ref || input["Fn::GetAtt"] || input["Fn::ImportValue"] || input["Fn::Sub"];
 	}
 
 	getLogicalId(name, type) {
@@ -187,6 +187,8 @@ class ServerlessSnsToSqsEvents {
 			return this.getLogicalId(snsName, "Topic");
 		} else if (snsArn.Ref) {
 			return snsArn.Ref;
+		} else if (snsArn["Fn::ImportValue"]) {
+			return this.getLogicalId(snsArn["Fn::ImportValue"], "Topic");
 		} else {
 			this.error(new Error("Unable to convert snsArn to logical Id", snsArn));
 		}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,6 +77,18 @@ describe("serverless-sns-to-sqs-events", () => {
     
 		noQueueOrTopicIsCreated(resources, snsArn, sqsArn, sqsUrl); 
 	});
+
+	test("when SNS is an ImportValue, no topic is created", () => {
+		const snsArn = { "Fn::ImportValue": "MyExportedTopic"};
+		const sqsArn = { "Fn::GetAtt": ["MyQueue", "Arn"] };
+		const sqsUrl = { Ref: "MyQueue" };
+		givenAnSnsToSqsEvent(snsArn, sqsArn);
+
+		snsToSqsPlugin.hooks[hook]();
+		const resources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+		 
+		noQueueOrTopicIsCreated(resources, snsArn, sqsArn, sqsUrl); 
+	});
   
 	test("when SQS is an ARN, no queue is created", () => {
 		const snsArn = { Ref: "MyTopic" };


### PR DESCRIPTION
I'm currently unable to configure a subscription to an existing SNS topic using ImportValue (see #3)

This gets it working it by updating the `isArn` method to look for `Fn::ImportValue` (instead of `Fn::Import`) and adding handling in `convertSnsArnToLogicalId`.

While this fixes the issue for my use case, I don't think this fix allows for an existing SQS queue to be referenced using ImportValue FYI